### PR TITLE
Introduce variable CS2_IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ STEAMGUARD=""               (Optional, Steam Guard key if enabled. Use your most
 
 ```dockerfile
 CS2_SERVERNAME="changeme"   (Set the visible name for your private server)
+CS2_IP=0.0.0.0              (CS2 server listening IP address, 0.0.0.0 - all IP addresses on the local machine, empty - IP identified automatically)
 CS2_PORT=27015              (CS2 server listen port tcp_udp)
 CS2_LAN="0"                 (0 - LAN mode disabled, 1 - LAN Mode enabled)
 CS2_RCONPW="changeme"       (RCON password)

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -33,6 +33,7 @@ RUN set -x \
 FROM build_stage AS bullseye-base
 
 ENV CS2_SERVERNAME="cs2 private server" \
+    CS2_IP=0.0.0.0 \
     CS2_PORT=27015 \
     CS2_MAXPLAYERS=10 \
     CS2_RCONPW="changeme" \

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -47,7 +47,7 @@ fi
 # Start Server
 
 eval "./cs2" -dedicated \
-        -port "${CS2_PORT}" \
+        -ip "${CS2_IP}" -port "${CS2_PORT}" \
         -console \
         -usercon \
         -maxplayers_override "${CS2_MAXPLAYERS}" \


### PR DESCRIPTION
The variable `CS2_IP` will be used in `entry.sh` for cs2 parameter `-ip` to set the tcp listener to a specific ip address.

default: 0.0.0.0 - listens to all IPs on the local machine, is probably the best.
left empty - cs2 try to identify the current ip automatically