### PR TITLE
maxplayers_override is deprecated. Use the launch option -maxplayers …

### DIFF
--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -50,7 +50,7 @@ eval "./cs2" -dedicated \
         -ip "${CS2_IP}" -port "${CS2_PORT}" \
         -console \
         -usercon \
-        -maxplayers_override "${CS2_MAXPLAYERS}" \
+        -maxplayers "${CS2_MAXPLAYERS}" \
         "${CS2_GAME_MODE_ARGS}" \
         +mapgroup "${CS2_MAPGROUP}" \
         +map "${CS2_STARTMAP}" \


### PR DESCRIPTION
	warning: In Counter-Strike 2, maxplayers_override is deprecated. Use the launch option -maxplayers <number> instead.

See https://developer.valvesoftware.com/wiki/Maxplayers
