### PR TITLE
Add support for RCON TCP proxy using simpleproxy. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ STEAMGUARD=""               (Optional, Steam Guard key if enabled. Use your most
 CS2_SERVERNAME="changeme"   (Set the visible name for your private server)
 CS2_IP=0.0.0.0              (CS2 server listening IP address, 0.0.0.0 - all IP addresses on the local machine, empty - IP identified automatically)
 CS2_PORT=27015              (CS2 server listen port tcp_udp)
+CS2_RCON_PORT=""            (Optional, use a simple TCP proxy to have RCON listen on an alternative port.
+                             Useful for services like AWS Fargate which do not support mixed protocol ports.)
 CS2_LAN="0"                 (0 - LAN mode disabled, 1 - LAN Mode enabled)
 CS2_RCONPW="changeme"       (RCON password)
 CS2_PW="changeme"           (CS2 server password)

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -1,6 +1,9 @@
 ###########################################################
 # Dockerfile that builds a CS2 Gameserver
 ###########################################################
+
+# BUILD STAGE
+
 FROM cm2network/steamcmd:root as build_stage
 
 LABEL maintainer="joedwards32@gmail.com"
@@ -23,18 +26,23 @@ RUN set -x \
 		wget \
 		ca-certificates \
 		lib32z1 \
+                simpleproxy \
 	&& mkdir -p "${STEAMAPPDIR}" \
 	# Add entry script
 	&& chmod +x "${HOMEDIR}/entry.sh" \
 	&& chown -R "${USER}:${USER}" "${HOMEDIR}/entry.sh" "${STEAMAPPDIR}" \
 	# Clean up
-	&& rm -rf /var/lib/apt/lists/* 
+        && apt-get clean \
+        && find /var/lib/apt/lists/ -type f -delete
+
+# BASE
 
 FROM build_stage AS bullseye-base
 
 ENV CS2_SERVERNAME="cs2 private server" \
     CS2_IP=0.0.0.0 \
     CS2_PORT=27015 \
+    CS2_RCON_PORT="" \
     CS2_MAXPLAYERS=10 \
     CS2_RCONPW="changeme" \
     CS2_PW="changeme" \

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -46,6 +46,11 @@ fi
 
 # Start Server
 
+if [[ ! -z $CS2_RCON_PORT ]]; then
+    echo "Establishing Simpleproxy for ${CS2_RCON_PORT} to 127.0.0.1:${CS2_PORT}"
+    simpleproxy -L "${CS2_RCON_PORT}" -R 127.0.0.1:"${CS2_PORT}" &
+fi
+
 eval "./cs2" -dedicated \
         -ip "${CS2_IP}" -port "${CS2_PORT}" \
         -console \


### PR DESCRIPTION
Useful for AWS Fargate in awsvpc networking mode.