### PR TITLE
add libicu-dev for support of CounterStrikeSharp

### DIFF
--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -27,6 +27,7 @@ RUN set -x \
 		ca-certificates \
 		lib32z1 \
                 simpleproxy \
+                libicu-dev \
 	&& mkdir -p "${STEAMAPPDIR}" \
 	# Add entry script
 	&& chmod +x "${HOMEDIR}/entry.sh" \


### PR DESCRIPTION
The currently most flexible and fututre proof way (imho) of writing Server plugins is a combination of Metamod and https://github.com/roflmuffin/CounterStrikeSharp . To run CounterStrikeSharp there is a dotnet runtime included in it, but the OS needs libicu in order to use the runtime.

Before we build a new container on your base with this single dependency added, i thought i PR it and see what you are thinking about adding it in here directly.

Have a good one!