### PR TITLE
Add support for Game Login Tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ This Docker image contains the dedicated server of the game.
 
 Running using Docker:
 ```console
-$ docker run -d --name=cs2 -p 27015:27015/tcp -p 27015:27015/udp -p 27020:27020/tcp joedwards32/cs2
+$ docker run -d --name=cs2 -e SRCDS_TOKEN={YOURTOKEN} -p 27015:27015/tcp -p 27015:27015/udp -p 27020:27020/tcp joedwards32/cs2
 ```
 
 Running using a bind mount for data persistence on container recreation:
 ```console
 $ mkdir -p $(pwd)/cs2-data
 $ chmod 777 $(pwd)/cs2-data # Makes sure the directory is writeable by the unprivileged container user
-$ docker run -d --name=cs2 -v $(pwd)/cs2-data:/home/steam/cs2-dedicated/ -p 27015:27015/tcp -p 27015:27015/udp -p 27020:27020/tcp joedwards32/cs2
+$ docker run -d --name=cs2 -e SRCDS_TOKEN={YOURTOKEN} -v $(pwd)/cs2-data:/home/steam/cs2-dedicated/ -p 27015:27015/tcp -p 27015:27015/udp -p 27020:27020/tcp joedwards32/cs2
 ```
 
 or using docker-compose, see [examples](https://github.com/joedwards32/CS2/blob/main/examples/docker-compose.yml):
 ```console
-# Remember to update passwords in your compose file
+# Remember to update passwords and SRCDS_TOKEN in your compose file
 $ docker compose --file examples/docker-compose.yml up -d cs2-server
 ```
 
@@ -49,6 +49,7 @@ Feel free to overwrite these environment variables, using -e (--env):
 ### Server Configuration
 
 ```dockerfile
+SRCDS_TOKEN=""              Game Server Token from https://steamcommunity.com/dev/managegameservers
 CS2_SERVERNAME="changeme"   (Set the visible name for your private server)
 CS2_IP=""                   (CS2 server listening IP address, 0.0.0.0 - all IP addresses on the local machine, empty - IP identified automatically)
 CS2_PORT=27015              (CS2 server listen port tcp_udp)

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -59,6 +59,7 @@ ENV CS2_SERVERNAME="cs2 private server" \
     TV_RELAY_PW="changeme" \
     TV_MAXRATE=0 \
     TV_DELAY=0 \
+    SRCDS_TOKEN="" \
     CS2_ADDITIONAL_ARGS=""
 
 # Set permissions on STEAMAPPDIR

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -70,6 +70,10 @@ else
     CS2_IP_ARGS="-ip ${CS2_IP}"
 fi
 
+if [[ ! -z $SRCDS_TOKEN ]]; then
+    SV_SETSTEAMACCOUNT_ARGS="+sv_setsteamaccount ${SRCDS_TOKEN}"
+fi
+
 # Start Server
 
 if [[ ! -z $CS2_RCON_PORT ]]; then
@@ -86,6 +90,7 @@ eval "./cs2" -dedicated \
         +mapgroup "${CS2_MAPGROUP}" \
         +map "${CS2_STARTMAP}" \
         +rcon_password "${CS2_RCONPW}" \
+        "${SV_SETSTEAMACCOUNT_ARGS}" \
         +sv_password "${CS2_PW}" \
         +sv_lan "${CS2_LAN}" \
         "${CS2_ADDITIONAL_ARGS}"

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     container_name: cs2-dedicated
     environment:
       # Server configuration
+      - SRCDS_TOKEN                 # Game Server Token from https://steamcommunity.com/dev/managegameservers
       - CS2_SERVERNAME=changeme     # (Set the visible name for your private server)
       - CS2_PORT=27015              # (CS2 server listen port tcp_udp)
       - CS2_RCON_PORT               # (Optional, use a simple TCP proxy to have RCON listen on an alternative port. Useful for services like AWS Fargate which do not support mixed protocol ports.)


### PR DESCRIPTION
Recent game update added new warning message in server log:

```
2023-11-29 22:30:07 ****************************************************
2023-11-29 22:30:07 *                                                  *
2023-11-29 22:30:07 *  No Steam account token was specified.           *
2023-11-29 22:30:07 *  Logging into anonymous game server account.     *
2023-11-29 22:30:07 *  Connections will be restricted to LAN only.     *
2023-11-29 22:30:07 *                                                  *
2023-11-29 22:30:07 *  To create a game server account go to           *
2023-11-29 22:30:07 *  http://steamcommunity.com/dev/managegameservers *
2023-11-29 22:30:07 *                                                  *
2023-11-29 22:30:07 ****************************************************
```

Fix to support Steam account tokens (Game Login Tokens) from https://steamcommunity.com/dev/managegameservers