### PR TITLE
Add "unzip" package and fix sed on restarts

### DIFF
--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -26,7 +26,7 @@ RUN set -x \
 		lib32z1 \
                 simpleproxy \
                 libicu-dev \
-                zip \
+                unzip \
 	&& mkdir -p "${STEAMAPPDIR}" \
 	# Add entry script
 	&& chmod +x "${HOMEDIR}/entry.sh" \

--- a/bullseye/Dockerfile
+++ b/bullseye/Dockerfile
@@ -26,6 +26,7 @@ RUN set -x \
 		lib32z1 \
                 simpleproxy \
                 libicu-dev \
+                zip \
 	&& mkdir -p "${STEAMAPPDIR}" \
 	# Add entry script
 	&& chmod +x "${HOMEDIR}/entry.sh" \

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -33,18 +33,20 @@ fi
 
 # Rewrite Config Files
 
-sed -i -e "s/{{SERVER_HOSTNAME}}/${CS2_SERVERNAME}/g" \
-       -e "s/{{SERVER_CHEATS}}/${CS2_CHEATS}/g" \
-       -e "s/{{SERVER_HIBERNATE}}/${CS2_SERVER_HIBERNATE}/g" \
-       -e "s/{{SERVER_PW}}/${CS2_PW}/g" \
-       -e "s/{{SERVER_RCON_PW}}/${CS2_RCONPW}/g" \
-       -e "s/{{TV_ENABLE}}/${TV_ENABLE}/g" \
-       -e "s/{{TV_PORT}}/${TV_PORT}/g" \
-       -e "s/{{TV_AUTORECORD}}/${TV_AUTORECORD}/g" \
-       -e "s/{{TV_PW}}/${TV_PW}/g" \
-       -e "s/{{TV_RELAY_PW}}/${TV_RELAY_PW}/g" \
-       -e "s/{{TV_MAXRATE}}/${TV_MAXRATE}/g" \
-       -e "s/{{TV_DELAY}}/${TV_DELAY}/g" \
+sed -r -i -e "s/^(hostname) .*/\1 ${CS2_SERVERNAME}/g" \
+       -e "s/^(sv_cheats) .*/\1 ${CS2_CHEATS}/g" \
+       -e "s/^(sv_hibernate_when_empty) .*/\1 ${CS2_SERVER_HIBERNATE}/g" \
+       -e "s/^(sv_password) .*/\1 ${CS2_PW}/g" \
+       -e "s/^(rcon_password) .*/\1 ${CS2_RCONPW}/g" \
+       -e "s/^(tv_enable) .*/\1 ${TV_ENABLE}/g" \
+       -e "s/^(tv_port) .*/\1 ${TV_PORT}/g" \
+       -e "s/^(tv_autorecord) .*/\1 ${TV_AUTORECORD}/g" \
+       -e "s/^(tv_password) .*/\1 ${TV_PW}/g" \
+       -e "s/^(tv_relaypassword) .*/\1 ${TV_RELAY_PW}/g" \
+       -e "s/^(tv_maxrate) .*/\1 ${TV_MAXRATE}/g" \
+       -e "s/^(tv_delay) .*/\1 ${TV_DELAY}/g" \
+       -e "s/^(tv_name) .*/\1 ${CS2_SERVERNAME} CSTV/g" \
+       -e "s/^(tv_title) .*/\1${CS2_SERVERNAME} CSTV/g" \
        "${STEAMAPPDIR}"/game/csgo/cfg/server.cfg
 
 if [[ ! -z $CS2_BOT_DIFFICULTY ]] ; then

--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -50,13 +50,13 @@ sed -r -i -e "s/^(hostname) .*/\1 ${CS2_SERVERNAME}/g" \
        "${STEAMAPPDIR}"/game/csgo/cfg/server.cfg
 
 if [[ ! -z $CS2_BOT_DIFFICULTY ]] ; then
-    sed -i "s/bot_difficulty.*/bot_difficulty ${CS2_BOT_DIFFICULTY}/" "${STEAMAPPDIR}"/game/csgo/cfg/*
+    sed -r -i "s/^(bot_difficulty) .*/\1 ${CS2_BOT_DIFFICULTY}/" "${STEAMAPPDIR}"/game/csgo/cfg/*
 fi
 if [[ ! -z $CS2_BOT_QUOTA ]] ; then
-    sed -i "s/bot_quota.*/bot_quota ${CS2_BOT_QUOTA}/" "${STEAMAPPDIR}"/game/csgo/cfg/*
+    sed -r -i "s/^(bot_quota) .*/\1 ${CS2_BOT_QUOTA}/" "${STEAMAPPDIR}"/game/csgo/cfg/*
 fi
 if [[ ! -z $CS2_BOT_QUOTA_MODE ]] ; then
-    sed -i "s/bot_quota_mode.*/bot_quota_mode ${CS2_BOT_QUOTA_MODE}/" "${STEAMAPPDIR}"/game/csgo/cfg/*
+    sed -r -i "s/^(bot_quota_mode) .*/\1 ${CS2_BOT_QUOTA_MODE}/" "${STEAMAPPDIR}"/game/csgo/cfg/*
 fi
 
 # Switch to server directory


### PR DESCRIPTION
Added the `unzip` package for use in `pre.sh` scripts that download plugins for CounterStrikeSharp e.g.
```bash
if [[ ! -d ${STEAMAPPDIR}/game/csgo/addons/counterstrikesharp/plugins/BasicAdmin ]]; then
    wget -q https://github.com/Hackmastr/css-basic-admin/releases/download/6c6034a/css-BasicAdmin-6c6034a.zip -O css-basicadmin.zip && unzip -q css-basicadmin.zip -d ${STEAMAPPDIR}/game/csgo/
fi
```

As well as changing the `sed` command so if you restart the server with a different value (say you change hostname in `docker-compose.yml`) it will update the `server.cfg` file correctly