### PR TITLE
Update cfg path

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ When using a persient volume mounted at `/home/steam/cs2-dedicated/` you may edi
 
 ## Overriding Game Mode Defaults
 
-The default configurations for each game mode are stored in `/home/steam/cs2-dedicated/csgo/cfg/`. For example, the Competitive mode defaults are set by `gamemode_competitive.cfg`.
+The default configurations for each game mode are stored in `/home/steam/cs2-dedicated/game/csgo/cfg/`. For example, the Competitive mode defaults are set by `gamemode_competitive.cfg`.
 
 When using a persistent volume mounted at `/home/steam/cs2-dedicated/`, these defaults can be overridden by adding your own settings to `gamemode_competitive_server.cfg`.
 


### PR DESCRIPTION
This appears to have changed. A currently running image from latest upstream has this mounted some place else:

```
$ cat docker-compose.yml               
services:
  cs2:
    image: joedwards32/cs2
    restart: unless-stopped
    volumes:
      - .state/cs2:/home/steam/cs2-dedicated
    env_file:
      - cs2.env
    ports:
      - "27015:27015/tcp"
      - "27015:27015/udp"
      - "27050:27050/tcp"

$ docker-compose exec cs2 ls /home/steam/cs2-dedicated/game/csgo/cfg/
gamemode_armsrace.cfg                gamemode_competitive_short.cfg  gamemode_deathmatch_short.cfg   gamemode_teamdeathmatch.cfg   user_keys_default.vcfg
gamemode_casual.cfg                  gamemode_competitive_tmm.cfg    gamemode_deathmatch_tmm.cfg     gamemode_workshop.cfg         user_keys_dev_default.vcfg
gamemode_competitive.cfg             gamemode_cooperative.cfg        gamemode_demolition.cfg         machine_convars_default.vcfg
gamemode_competitive2v2.cfg          gamemode_coopmission.cfg        gamemode_dm_freeforall.cfg      perftest.cfg
gamemode_competitive2v2_offline.cfg  gamemode_custom.cfg             gamemode_new_user_training.cfg  server.cfg
gamemode_competitive_offline.cfg     gamemode_deathmatch.cfg         gamemode_retakecasual.cfg       server_default.cfg
```

Maybe that's a remnant from CS:GO turning into CS2?