### PR TITLE
 Add local console for docker attach

### DIFF
--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -47,5 +47,7 @@ services:
       - "27015:27015/tcp"           # TCP
       - "27015:27015/udp"           # UDP
       - "27020:27020/udp"           # UDP
+    stdin_open: true # Add local console for docker attach, docker attach --sig-proxy=false cs2-dedicated
+    tty: true # Add local console for docker attach, docker attach --sig-proxy=false cs2-dedicated
 volumes:
   cs2:


### PR DESCRIPTION
# Why
Need a local console to directly control the dedicated server without rcon.
# How to attach

docker attach --sig-proxy=false cs2-dedicated
or
docker attach --detach-keys="ctrl-x" cs2-dedicated
# How to detach
## Please do not use ctrl + c
use 
> ctrl + p + q

or

> ctrl + x (docker attach --detach-keys="ctrl-x" cs2-dedicated)
