### PR TITLE
Use source instead of creating a subshell

### DIFF
--- a/bullseye/etc/entry.sh
+++ b/bullseye/etc/entry.sh
@@ -71,7 +71,7 @@ fi
 cd "${STEAMAPPDIR}/game/bin/linuxsteamrt64"
 
 # Pre Hook
-bash "${STEAMAPPDIR}/pre.sh"
+source "${STEAMAPPDIR}/pre.sh"
 
 # Construct server arguments
 
@@ -116,4 +116,4 @@ eval "./cs2" -dedicated \
         "${CS2_ADDITIONAL_ARGS}"
 
 # Post Hook
-bash "${STEAMAPPDIR}/post.sh"
+source "${STEAMAPPDIR}/post.sh"


### PR DESCRIPTION
So that the environment values can be inherited from the pre/post scripts and propagate to the launch options, which is especially great for Agones scripting