### PR TITLE
Add warning regarding "/" in CS2_SERVERNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,15 @@ Minimum system requirements are:
 * 40GB of disk space for the container or mounted as a persistent volume on `/home/steam/cs2-dedicated/`
 
 ## Environment Variables
-Feel free to overwrite these environment variables, using -e (--env): 
+Feel free to overwrite these environment variables, using -e (--env):
+
+**Note:** `/` characters in Counter-Strike-related environment variables **must be escaped** as `\/` (e. g. `CS2_SERVERNAME="My Server 1\/3` will result in `My Server 1/3` in-game). Otherwise, this may cause unexpected behavior during configuration processing 
 
 ### Server Configuration
 
 ```dockerfile
 SRCDS_TOKEN=""              (Game Server Token from https://steamcommunity.com/dev/managegameservers)
-CS2_SERVERNAME="changeme"   (Set the visible name for your private server. DO NOT USE "/" in your server name!)
+CS2_SERVERNAME="changeme"   (Set the visible name for your private server.)
 CS2_CHEATS=0                (0 - disable cheats, 1 - enable cheats)
 CS2_SERVER_HIBERNATE=0      (Put server in a low CPU state when there are no players. 
                              0 - hibernation disabled, 1 - hibernation enabled

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Feel free to overwrite these environment variables, using -e (--env):
 
 ```dockerfile
 SRCDS_TOKEN=""              (Game Server Token from https://steamcommunity.com/dev/managegameservers)
-CS2_SERVERNAME="changeme"   (Set the visible name for your private server)
+CS2_SERVERNAME="changeme"   (Set the visible name for your private server. DO NOT USE "/" in your server name!)
 CS2_CHEATS=0                (0 - disable cheats, 1 - enable cheats)
 CS2_SERVER_HIBERNATE=0      (Put server in a low CPU state when there are no players. 
                              0 - hibernation disabled, 1 - hibernation enabled

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - SRCDS_TOKEN                 # Game Server Token from https://steamcommunity.com/dev/managegameservers
       - DEBUG=0                     # (0 - off, 1 - steamcmd, 2 - cs2, 3 - all)
       - STEAMAPPVALIDATE=0          # (0 - no validation, 1 - enable validation)
-      - CS2_SERVERNAME=changeme     # (Set the visible name for your private server)
+      - CS2_SERVERNAME=changeme     # (Set the visible name for your private server. DO NOT USE "/" in your server name!)
       - CS2_CHEATS=0                # (0 - disable cheats, 1 - enable cheats)
       - CS2_PORT=27015              # (CS2 server listen port tcp_udp)
       - CS2_SERVER_HIBERNATE=0      # (Put server in a low CPU state when there are no players. 0 - hibernation disabled, 1 - hibernation enabled)

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - SRCDS_TOKEN                 # Game Server Token from https://steamcommunity.com/dev/managegameservers
       - DEBUG=0                     # (0 - off, 1 - steamcmd, 2 - cs2, 3 - all)
       - STEAMAPPVALIDATE=0          # (0 - no validation, 1 - enable validation)
-      - CS2_SERVERNAME=changeme     # (Set the visible name for your private server. DO NOT USE "/" in your server name!)
+      - CS2_SERVERNAME=changeme     # (Set the visible name for your private server.)
       - CS2_CHEATS=0                # (0 - disable cheats, 1 - enable cheats)
       - CS2_PORT=27015              # (CS2 server listen port tcp_udp)
       - CS2_SERVER_HIBERNATE=0      # (Put server in a low CPU state when there are no players. 0 - hibernation disabled, 1 - hibernation enabled)


### PR DESCRIPTION
Using a "/" character in the CS2_SERVERNAME (e.g., "CS Server 1/3 of My Amazing LAN Party") causes the sed substitution in
https://github.com/joedwards32/CS2/blob/38b2938f7927c5f83e62fe32fe23f37e1f2201cb/bookworm/etc/entry.sh#L103to fail because the default delimiter "/" conflicts with the character in the value. Although the server continues to run, the configuration file ends up with unresolved placeholders (for example, `{{SERVER_CHEATS}}` remains unchanged). As a result, when players try to connect, they receive a "wrong password" error - even if the password is correct or none was set initially.

**How to Reproduce:**
1.  take the example docker-compose.yml https://github.com/joedwards32/CS2/blob/38b2938f7927c5f83e62fe32fe23f37e1f2201cb/examples/docker-compose.yml
2. change the CS2_SERVERNAME to "Server 1/3"
3. docker compose up
4. connect to server
5. wrong password :( 

**Recommendation:**
It is a lot of work to allow all sorts of arbitrary characters. I suggest just adding a warning in both the README and the example docker-compose.yml. I could provide another solution if requested.

_Thank you for this amazing docker image and all of your work. It has been serving me and my friends well on our LAN parties <3 This is my first pull request ever created, so I hope the format and description are acceptable._