### PR TITLE
update size requirement from 50GB to 60GB

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ or using docker-compose, see [examples](https://github.com/joedwards32/CS2/blob/
 $ docker compose --file examples/docker-compose.yml up -d cs2-server
 ```
 
-You must have at least **50GB** of free disk space! See [System Requirements](./#system-requirements).
+You must have at least **60GB** of free disk space! See [System Requirements](./#system-requirements).
 
 **The container will automatically update the game on startup, so if there is a game update just restart the container.**
 
@@ -43,7 +43,7 @@ Minimum system requirements are:
 
 * 2 CPUs
 * 2GiB RAM
-* 50GB of disk space for the container or mounted as a persistent volume on `/home/steam/cs2-dedicated/`
+* 60GB of disk space for the container or mounted as a persistent volume on `/home/steam/cs2-dedicated/`
   * Note: More space may be required if you plan to install mods
 
 ## Environment Variables


### PR DESCRIPTION
This pull request updates the disk space requirement for running the container to ensure users allocate enough storage for the application. The minimum recommended disk space has been increased from 50GB to 60GB in both the installation instructions and the system requirements section of the `README.md`.

Documentation updates:

* Increased the minimum disk space requirement from 50GB to 60GB in the installation instructions section of `README.md` to help prevent storage issues during setup.
* Updated the minimum system requirements in `README.md` to reflect the new 60GB disk space recommendation for the container or persistent volume.

fixes #170 