### PR TITLE
Change tv_delay in gamemode_competitive.cfg

### DIFF
--- a/sniper/etc/entry.sh
+++ b/sniper/etc/entry.sh
@@ -128,6 +128,16 @@ if [[ ! -z $CS2_BOT_QUOTA_MODE ]] ; then
     sed -i "s/bot_quota_mode.*/bot_quota_mode ${CS2_BOT_QUOTA_MODE}/" "${STEAMAPPDIR}"/game/csgo/cfg/*
 fi
 
+# Rewrite tv_delay in gamemode_competitive.cfg (because it supersedes the value in server.cfg)
+if [[ -n "${TV_DELAY}" ]]; then
+    COMPETITIVE_CFG="${STEAMAPPDIR}/game/csgo/cfg/gamemode_competitive.cfg"
+    if grep -q "^tv_delay" "$COMPETITIVE_CFG"; then
+        sed -ri "s/^tv_delay[[:space:]]+.*/tv_delay ${TV_DELAY}/" "$COMPETITIVE_CFG"
+    else
+        echo "tv_delay ${TV_DELAY}" >> "$COMPETITIVE_CFG"
+    fi
+fi
+
 # Switch to server directory
 cd "${STEAMAPPDIR}/game/"
 


### PR DESCRIPTION
The `TV_DELAY` variable currently has no effect. It only writes it into the `server.cfg` file. However, it is overruled by the tv_delay value in `gamemode_competitive.cfg` (and probably it's the same for other game modes).

This PR fixed the problem for me in competitive games. If, however, you prefer a more global solution for all game modes, let me know, and I'll adapt the code.

Best regards,
Pascal