### PR TITLE
Additional logging configuration for HLTV required configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ CS2_LOG="on"                ('on'/'off')
 CS2_LOG_MONEY=0             (Turns money logging on/off: 0=off, 1=on)
 CS2_LOG_DETAIL=0            (Combat damage logging: 0=disabled, 1=enemy, 2=friendly, 3=all)
 CS2_LOG_ITEMS=0             (Turns item logging on/off: 0=off, 1=on)
+CS2_LOG_FILE=0              (Turns logging into a file on/off: 0=off, 1=on)
+CS2_LOG_ECHO=0              (This command sets whether or not all of text that is saved to the log file is also written in the console: 0=off, 1=on)
+CS2_DISCONNECT_KILLS=1      (Turning this command on causes players to die in game if they disconnect: 0=off, 1=on)
+CS2_LOG_HTTP_URL="<endpoint-url>" (This command is used to set URI of a listener to receive logs via HTTP POST. The URI must be wrapped in double quotes.)
 ```
 
 ### Steam Workshop

--- a/sniper/Dockerfile
+++ b/sniper/Dockerfile
@@ -90,6 +90,7 @@ ENV CS2_SERVERNAME="cs2 private server" \
     CS2_CFG_URL="" \
     CS2_LOG="on" \
     CS2_LOG_FILE=0 \
+    CS2_LOG_ECHO=0 \
     CS2_LOG_MONEY=0 \
     CS2_LOG_DETAIL=0 \
     CS2_LOG_ITEMS=0 \

--- a/sniper/Dockerfile
+++ b/sniper/Dockerfile
@@ -89,9 +89,12 @@ ENV CS2_SERVERNAME="cs2 private server" \
     SRCDS_TOKEN="" \
     CS2_CFG_URL="" \
     CS2_LOG="on" \
+    CS2_LOG_FILE=0 \
     CS2_LOG_MONEY=0 \
     CS2_LOG_DETAIL=0 \
     CS2_LOG_ITEMS=0 \
+    CS2_DISCONNECT_KILLS=0 \
+    CS2_LOG_HTTP_URL="" \
     CS2_ADDITIONAL_ARGS=""
 
 # Set permissions on STEAMAPPDIR

--- a/sniper/etc/entry.sh
+++ b/sniper/etc/entry.sh
@@ -115,6 +115,7 @@ sed -i -e "s/{{SERVER_HOSTNAME}}/${CS2_SERVERNAME}/g" \
        -e "s/{{TV_DELAY}}/${TV_DELAY}/g" \
        -e "s/{{SERVER_LOG}}/${CS2_LOG}/g" \
        -e "s/{{SERVER_LOG_FILE}}/${CS2_LOG_FILE}/g" \
+       -e "s/{{SERVER_LOG_ECHO}}/${CS2_LOG_ECHO}/g" \
        -e "s/{{SERVER_LOG_MONEY}}/${CS2_LOG_MONEY}/g" \
        -e "s/{{SERVER_LOG_DETAIL}}/${CS2_LOG_DETAIL}/g" \
        -e "s/{{SERVER_LOG_ITEMS}}/${CS2_LOG_ITEMS}/g" \

--- a/sniper/etc/entry.sh
+++ b/sniper/etc/entry.sh
@@ -9,6 +9,7 @@ fi
 ## CS2 server debugging
 if [[ $DEBUG -eq 2 ]] || [[ $DEBUG -eq 3 ]]; then
     CS2_LOG="on"
+    CS2_LOG_FILE=1
     CS2_LOG_MONEY=1
     CS2_LOG_DETAIL=3
     CS2_LOG_ITEMS=1
@@ -113,10 +114,16 @@ sed -i -e "s/{{SERVER_HOSTNAME}}/${CS2_SERVERNAME}/g" \
        -e "s/{{TV_MAXRATE}}/${TV_MAXRATE}/g" \
        -e "s/{{TV_DELAY}}/${TV_DELAY}/g" \
        -e "s/{{SERVER_LOG}}/${CS2_LOG}/g" \
+       -e "s/{{SERVER_LOG_FILE}}/${CS2_LOG_FILE}/g" \
        -e "s/{{SERVER_LOG_MONEY}}/${CS2_LOG_MONEY}/g" \
        -e "s/{{SERVER_LOG_DETAIL}}/${CS2_LOG_DETAIL}/g" \
        -e "s/{{SERVER_LOG_ITEMS}}/${CS2_LOG_ITEMS}/g" \
+       -e "s/{{SERVER_DISCONNECT_KILLS}}/${CS2_DISCONNECT_KILLS}/g" \
        "${STEAMAPPDIR}"/game/csgo/cfg/server.cfg
+
+if [[ ! -z $CS2_LOG_HTTP_URL ]]; then
+    printf 'logaddress_add_http "%s"\n' "${CS2_LOG_HTTP_URL}" >> "${STEAMAPPDIR}"/game/csgo/cfg/server.cfg
+fi
 
 if [[ ! -z $CS2_BOT_DIFFICULTY ]] ; then
     sed -i "s/bot_difficulty.*/bot_difficulty ${CS2_BOT_DIFFICULTY}/" "${STEAMAPPDIR}"/game/csgo/cfg/*

--- a/sniper/etc/server.cfg
+++ b/sniper/etc/server.cfg
@@ -39,6 +39,8 @@ tv_transmitall 1                              // Transmit all entities (not only
 // Logs
 
 log {{SERVER_LOG}}                            // Turns logging 'on' or 'off', defaults to 'on'
+sv_logfile {{SERVER_LOG_FILE}}                // Log game events to a log file: 0=off, 1=on
 mp_logmoney {{SERVER_LOG_MONEY}}              // Turns money logging on/off: 0=off, 1=on
 mp_logdetail {{SERVER_LOG_DETAIL}}            // Combat damage logging: 0=disabled, 1=enemy, 2=friendly, 3=all
 mp_logdetail_items {{SERVER_LOG_ITEMS}}       // Turns item logging on/off: 0=off, 1=on
+mp_disconnect_kills_players {{SERVER_DISCONNECT_KILLS}} // Kill players on disconnect: 0=off, 1=on

--- a/sniper/etc/server.cfg
+++ b/sniper/etc/server.cfg
@@ -40,6 +40,7 @@ tv_transmitall 1                              // Transmit all entities (not only
 
 log {{SERVER_LOG}}                            // Turns logging 'on' or 'off', defaults to 'on'
 sv_logfile {{SERVER_LOG_FILE}}                // Log game events to a log file: 0=off, 1=on
+sv_logecho {{SERVER_LOG_ECHO}}                // Echo log output to console: 0=off, 1=on
 mp_logmoney {{SERVER_LOG_MONEY}}              // Turns money logging on/off: 0=off, 1=on
 mp_logdetail {{SERVER_LOG_DETAIL}}            // Combat damage logging: 0=disabled, 1=enemy, 2=friendly, 3=all
 mp_logdetail_items {{SERVER_LOG_ITEMS}}       // Turns item logging on/off: 0=off, 1=on


### PR DESCRIPTION
Hello! In order for HLTV.org to recieve game info logs (for live feed) they rely on server sending the logs to an endpoint. As I could have solved this via the remote download cfg (this feature i absolutely despise), that would not be efficient for multi server setup in which I would need the endpoints to be different. So i would need to upkeep 2 cfg downloads and since endpoint address is sensitive information, it would be rather stupid to upload it for public access in situations where firewall is not an option. 

Hence this solution - to add required configuration so TO's wouldnt have to fork your image and could just plug and play this at tournaments covered by HLTV.org.

P.S. I sneaked in logecho too and that is needed for get5api.