### PR TITLE
Docker compose example for lancache compatible configuration

### DIFF
--- a/sniper/etc/entry.sh
+++ b/sniper/etc/entry.sh
@@ -216,7 +216,7 @@ eval "./cs2.sh" -dedicated \
         "${CS2_PW_ARGS}" \
         +sv_lan "${CS2_LAN}" \
         +tv_port "${TV_PORT}" \
-        ${CS2_ADDITIONAL_ARGS}
+        "${CS2_ADDITIONAL_ARGS}"
 
 # Post Hook
 source "${STEAMAPPDIR}/post.sh"

--- a/sniper/etc/entry.sh
+++ b/sniper/etc/entry.sh
@@ -216,7 +216,7 @@ eval "./cs2.sh" -dedicated \
         "${CS2_PW_ARGS}" \
         +sv_lan "${CS2_LAN}" \
         +tv_port "${TV_PORT}" \
-        "${CS2_ADDITIONAL_ARGS}"
+        ${CS2_ADDITIONAL_ARGS}
 
 # Post Hook
 source "${STEAMAPPDIR}/post.sh"


### PR DESCRIPTION
This PR adds a docker compose example with LanCache compatible config:
- DNS redirection to LanCache IP
- Network with IPv6 config to force resolution through IPv4