### PR TITLE
sed fails if cfg contains subdirectories

### DIFF
--- a/sniper/etc/entry.sh
+++ b/sniper/etc/entry.sh
@@ -216,7 +216,7 @@ eval "./cs2.sh" -dedicated \
         "${CS2_PW_ARGS}" \
         +sv_lan "${CS2_LAN}" \
         +tv_port "${TV_PORT}" \
-        ${CS2_ADDITIONAL_ARGS}
+        "${CS2_ADDITIONAL_ARGS}"
 
 # Post Hook
 source "${STEAMAPPDIR}/post.sh"

--- a/sniper/etc/entry.sh
+++ b/sniper/etc/entry.sh
@@ -216,7 +216,7 @@ eval "./cs2.sh" -dedicated \
         "${CS2_PW_ARGS}" \
         +sv_lan "${CS2_LAN}" \
         +tv_port "${TV_PORT}" \
-        "${CS2_ADDITIONAL_ARGS}"
+        ${CS2_ADDITIONAL_ARGS}
 
 # Post Hook
 source "${STEAMAPPDIR}/post.sh"


### PR DESCRIPTION
@joedwards32 Currently, the sed commands target everything in the cfg-folder. But apparently, there can be sub-directories:

```
(steamrt sniper 3.0.20260805.254768)steam@2e12c3fbc53a:~/cs2-dedicated/game/csgo/cfg$ ls -al
total 160
drwxr-xr-x  3 steam steam  4096 Aug 30 20:51 .
drwxr-xr-x 10 steam steam 20480 Aug 30 20:45 ..
drwxr-xr-x  2 steam steam  4096 Aug 30 10:32 devonly     <======================== sub-directory
-rwxr-xr-x  1 steam steam  4262 Aug 30 20:51 gamemode_armsrace.cfg
-rwxr-xr-x  1 steam steam  4436 Aug 30 20:51 gamemode_casual.cfg
-rwxr-xr-x  1 steam steam  4367 Aug 30 20:51 gamemode_competitive.cfg
-rwxr-xr-x  1 steam steam  4271 Aug 30 20:51 gamemode_competitive2v2.cfg
-rwxr-xr-x  1 steam steam   132 Aug 30 20:51 gamemode_competitive2v2_offline.cfg
-rwxr-xr-x  1 steam steam   134 Aug 30 20:51 gamemode_competitive_offline.cfg
-rwxr-xr-x  1 steam steam   102 Aug 30 20:51 gamemode_competitive_short.cfg
-rwxr-xr-x  1 steam steam   766 Aug 30 20:51 gamemode_competitive_tmm.cfg
-rwxr-xr-x  1 steam steam  1978 Aug 30 20:51 gamemode_cooperative.cfg
-rwxr-xr-x  1 steam steam  3651 Aug 30 20:51 gamemode_coopmission.cfg
-rwxr-xr-x  1 steam steam    75 Aug 30 20:51 gamemode_custom.cfg
-rwxr-xr-x  1 steam steam  4446 Aug 30 20:51 gamemode_deathmatch.cfg
-rwxr-xr-x  1 steam steam   243 Aug 30 20:51 gamemode_deathmatch_short.cfg
-rwxr-xr-x  1 steam steam   789 Aug 30 20:51 gamemode_deathmatch_tmm.cfg
-rwxr-xr-x  1 steam steam  3772 Aug 30 20:51 gamemode_demolition.cfg
-rwxr-xr-x  1 steam steam  4067 Aug 30 20:51 gamemode_dm_freeforall.cfg
-rwxr-xr-x  1 steam steam   509 Aug 30 20:51 gamemode_new_user_training.cfg
-rwxr-xr-x  1 steam steam  4219 Aug 30 20:51 gamemode_retakecasual.cfg
-rwxr-xr-x  1 steam steam  3786 Aug 30 20:51 gamemode_teamdeathmatch.cfg
-rwxr-xr-x  1 steam steam  3818 Aug 30 20:51 gamemode_workshop.cfg
-rwxr-xr-x  1 steam steam   313 Aug 17 19:24 machine_convars_default.vcfg
-rwxr-xr-x  1 steam steam  3367 Aug 30 20:51 perftest.cfg
-rwxr-xr-x  1 steam steam  2856 Aug 30 20:51 server.cfg
-rwxr-xr-x  1 steam steam   370 Aug 30 20:51 server_default.cfg
-rwxr-xr-x  1 steam steam  1232 Aug 17 19:24 user_keys_default.vcfg
-rwxr-xr-x  1 steam steam  1447 Aug 17 19:24 user_keys_dev_default.vcfg
```

In this case, the sed-commands fail instantly and the CS2_BOT* env vars are not applied.
This fix makes the sed commands only target `gamemode_*.cfg` files.